### PR TITLE
Handle mouse leaving canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,8 +104,17 @@
         canvas.addEventListener('mousemove', (e) => {
             if (!dragging) return;
             const pos = getPos(e);
-            endX = pos.x;
-            endY = pos.y;
+            endX = Math.max(0, Math.min(pos.x, canvas.width));
+            endY = Math.max(0, Math.min(pos.y, canvas.height));
+            redraw();
+        });
+
+        canvas.addEventListener('mouseleave', (e) => {
+            if (!dragging) return;
+            const pos = getPos(e);
+            endX = Math.max(0, Math.min(pos.x, canvas.width));
+            endY = Math.max(0, Math.min(pos.y, canvas.height));
+            dragging = false;
             redraw();
         });
 


### PR DESCRIPTION
## Summary
- clamp mouse positions to canvas bounds and finalize selection when leaving the canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843ad410548832cbae3abcbebea0765