### PR TITLE
Update README with live site info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # image_cutter
 
-This repository hosts a minimal static site served via GitHub Pages.
+This repository hosts a minimal static site served via GitHub Pages. It is a website where you can cut images.
 
 GitHub Pages is already enabled for the `main` branch using the `/ (root)` folder, so `index.html` is served as the site homepage.
 
-You can visit the site at [https://kotabrog.github.io/image_cutter/](https://kotabrog.github.io/image_cutter/).
+You can visit the live site at [https://kotabrog.github.io/image_cutter/](https://kotabrog.github.io/image_cutter/).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # image_cutter
 
-This repository contains a minimal static site for GitHub Pages.
+This repository hosts a minimal static site served via GitHub Pages.
 
-To publish the site, enable GitHub Pages in the repository settings and select
-`main` as the branch, using the `/ (root)` folder. Once enabled, the
-`index.html` file will be served as the site homepage.
+GitHub Pages is already enabled for the `main` branch using the `/ (root)` folder, so `index.html` is served as the site homepage.
+
+You can visit the site at [https://kotabrog.github.io/image_cutter/](https://kotabrog.github.io/image_cutter/).


### PR DESCRIPTION
## Summary
- reflect that GitHub Pages is already enabled
- link to the published site

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6844d5f7b9e8832c8fd54a7fc07bb9fc